### PR TITLE
ci: publish dorker image to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,27 +10,35 @@ on:
     paths:
       - 'Dockerfile'
       - 'dnf-packages.list'
-      - '.github/workflows/build.yml'
+      - '.github/workflows/ci.yaml'
   pull_request:
     branches:
       - main
     paths:
       - 'Dockerfile'
       - 'dnf-packages.list'
-      - '.github/workflows/build.yml'
+      - '.github/workflows/ci.yaml'
+
+permissions:
+  contents: read
+  packages: write
+
 env:
-  REGISTRY_IMAGE: darthfork/dorker
+  REGISTRY: ghcr.io
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/dorker
 
 jobs:
   build:
     name: Build Container Image for ${{ matrix.platform }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/arm64
-          - linux/amd64
+        include:
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/amd64
+            runner: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,20 +61,17 @@ jobs:
             type=raw,value=${{ steps.prep.outputs.tag }}
             type=raw,value=${{ steps.prep.outputs.ostag }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log into registry
+      - name: Log into GHCR
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         uses: docker/build-push-action@v6
@@ -79,15 +84,17 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.ref == 'refs/heads/main' }}
 
       - name: Export digest
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
@@ -125,11 +132,12 @@ jobs:
             type=raw,value=${{ needs.build.outputs.tag }}
             type=raw,value=${{ needs.build.outputs.ostag }}
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM fedora:42
 
+LABEL org.opencontainers.image.source="https://github.com/darthfork/dorker"
+
 ARG TARGETARCH
 ARG USERNAME=darthfork
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include version
 
 DIR		:= ${CURDIR}
 IMAGE		:= dorker
-ACCOUNT		:= darthfork
+ACCOUNT		:= ghcr.io/darthfork
 REPO 		:= $(ACCOUNT)/$(IMAGE):$(TAG)
 REPO_OS 	:= $(ACCOUNT)/$(IMAGE):$(TAG_OS)
 TARGETPLATFORM	:= linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Fedora Docker with all my commonly used dev tools installed
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/darthfork/dorker/ci.yaml?style=for-the-badge&logo=github)](https://github.com/darthfork/dorker/actions/workflows/ci.yaml)
 
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/darthfork/dorker/latest?logo=docker&style=for-the-badge)](https://hub.docker.com/r/darthfork/dorker/)
+[![Container Image Size (tag)](https://img.shields.io/badge/container-ghcr.io%2Fdarthfork%2Fdorker-blue?logo=github&style=for-the-badge)](https://github.com/darthfork/dorker/pkgs/container/dorker)
 
 
 ## Starting a shell in the container
@@ -15,7 +15,7 @@ docker run -it\
     -v "$HOME"/.kube:/darthfork/.kube\
     -e AWS_PROFILE\
     -h dorker\
-    docker.io/darthfork/dorker:latest /bin/bash
+    ghcr.io/darthfork/dorker:latest /bin/bash
 ```
 
 ## Run `dorker` in Kubernetes


### PR DESCRIPTION
## Summary
- publish dorker images to GHCR using `GITHUB_TOKEN`
- split multi-arch builds across native runners (`ubuntu-24.04-arm` for arm64, `ubuntu-24.04` for amd64)
- remove QEMU from CI and keep PR builds validation-only
- update local image refs/docs to `ghcr.io/darthfork/dorker`

## Test Plan
- `git diff --check`
- PyYAML parse of `.github/workflows/ci.yaml`
- `make lint` / `hadolint Dockerfile`
