### PR TITLE
feat: switch dorker base to Ubuntu noble

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,14 +9,14 @@ on:
       - main
     paths:
       - 'Dockerfile'
-      - 'dnf-packages.list'
+      - 'apt-packages.list'
       - '.github/workflows/ci.yaml'
   pull_request:
     branches:
       - main
     paths:
       - 'Dockerfile'
-      - 'dnf-packages.list'
+      - 'apt-packages.list'
       - '.github/workflows/ci.yaml'
 
 permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,17 @@ RUN set -ex \
 RUN set -ex \
     && curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
-RUN groupadd -g 1000 -r ${USERNAME} \
-    && useradd -r -g ${USERNAME} -u 1000 -m -d /${USERNAME}/ ${USERNAME}
+RUN set -eux; \
+    if getent group 1000 >/dev/null; then \
+        groupmod -n ${USERNAME} "$(getent group 1000 | cut -d: -f1)"; \
+    else \
+        groupadd -g 1000 ${USERNAME}; \
+    fi; \
+    if getent passwd 1000 >/dev/null; then \
+        usermod -l ${USERNAME} -d /${USERNAME}/ -m "$(getent passwd 1000 | cut -d: -f1)"; \
+    else \
+        useradd -g ${USERNAME} -u 1000 -m -d /${USERNAME}/ ${USERNAME}; \
+    fi
 
 WORKDIR /${USERNAME}/workspace/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,52 @@
-FROM fedora:42
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source="https://github.com/darthfork/dorker"
 
+ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 ARG USERNAME=darthfork
 
-COPY dnf-packages.list /tmp/dnf-packages.list
+COPY apt-packages.list /tmp/apt-packages.list
 
-RUN dnf -y update && dnf -y install $(cat /tmp/dnf-packages.list) && dnf -y clean all
+RUN apt-get update \
+    && xargs -a /tmp/apt-packages.list apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* /tmp/apt-packages.list
 
-# Install binaries not available in dnf
+# Install binaries not available in apt, or where apt lags too far behind.
 
 WORKDIR /usr/local/bin
 
 # aws cli
 RUN set -ex \
     && if [ "$TARGETARCH" = "arm64" ]; then \
-        curl -s -o awscli.zip https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip; \
+        curl -sSLo awscli.zip https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip; \
     else \
-        curl -s -o awscli.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip; \
+        curl -sSLo awscli.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip; \
     fi \
-    && unzip -d awscli awscli.zip \
+    && unzip -q -d awscli awscli.zip \
     && ./awscli/aws/install \
     && rm -rf awscli.zip awscli
 
 # kubectl
 ARG KUBECTL_VERSION=1.31.0
 RUN set -ex \
-    && curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
+    && curl -fsSLO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl \
     && chmod 755 kubectl
 
 # terraform
 ARG TERRAFORM_VERSION=1.9.8
 RUN set -ex \
-    && curl -s -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \
-    && unzip terraform.zip \
+    && curl -fsSLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \
+    && unzip -q terraform.zip \
     && rm -f terraform.zip \
     && chmod 755 terraform
 
 # helm
 RUN set -ex \
-    && curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+    && curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
-RUN groupadd -g 1000 -r ${USERNAME} &&\
-    useradd -r -g ${USERNAME} -u 1000 -m -d /${USERNAME}/ ${USERNAME}
+RUN groupadd -g 1000 -r ${USERNAME} \
+    && useradd -r -g ${USERNAME} -u 1000 -m -d /${USERNAME}/ ${USERNAME}
 
 WORKDIR /${USERNAME}/workspace/
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Dorker
-Fedora Docker with all my commonly used dev tools installed
+Ubuntu Docker with all my commonly used dev tools installed
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/darthfork/dorker/ci.yaml?style=for-the-badge&logo=github)](https://github.com/darthfork/dorker/actions/workflows/ci.yaml)
 

--- a/apt-packages.list
+++ b/apt-packages.list
@@ -1,5 +1,8 @@
-awk
+ca-certificates
+curl
+gawk
 git
+gnupg
 make
 openssl
 python3

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
 TAG=latest
-TAG_OS=fedora40
+TAG_OS=noble


### PR DESCRIPTION
## Summary
- switch dorker from Fedora 42 to Ubuntu 24.04/Noble
- replace `dnf-packages.list` with `apt-packages.list`
- keep AWS CLI, kubectl, Terraform, and Helm installed directly from upstream binaries/scripts
- retag the OS image variant as `noble`

## Test Plan
- `git diff --check`
- PyYAML parse of `.github/workflows/ci.yaml`
- `make lint` / `hadolint Dockerfile`

Note: local Docker build was blocked by stale Docker Hub auth on this machine while pulling `ubuntu:24.04`; PR CI will validate the actual build on clean GitHub runners.
